### PR TITLE
fetch latest release version & use bash tool

### DIFF
--- a/bin/flyway
+++ b/bin/flyway
@@ -10,11 +10,11 @@ let resolver = require('../jlib/resolver');
 
 process.title = 'flyway';
 program
-    .version(pkg.version)
-    .option('-c, --configfile <file>', 'A javascript or json file containing configuration.')
-    .on('--help', function() {
-        console.log('  See Flyway\'s configuration options at https://flywaydb.org/documentation/commandline/');
-    });
+  .version(pkg.version)
+  .option('-c, --configfile <file>', 'A javascript or json file containing configuration.')
+  .on('--help', function () {
+    console.log('  See Flyway\'s configuration options at https://flywaydb.org/documentation/commandline/');
+  });
 
 makeCommand('migrate', 'Migrates the schema to the latest version. Flyway will create the metadata table automatically if it doesn\'t exist.');
 makeCommand('clean', 'Drops all objects (tables, views, procedures, triggers, ...) in the configured schemas. The schemas are cleaned in the order specified by the schemas property.');
@@ -35,31 +35,29 @@ makeCommand('repair', `Repairs the Flyway metadata table. This will perform the 
 program.parse(process.argv);
 
 function makeCommand(name, desc) {
-    program
-        .command(name)
-        .description(desc)
-        .action(exeCommand);
+  program
+    .command(name)
+    .description(desc)
+    .action(exeCommand);
 }
 
 function exeCommand(cmd) {
-    let cwd = process.cwd(),
-        config = require(path.resolve(program.configfile)), 
-        configArgs = Object.keys(config),
-        relativeLibDirs = resolver.libDirs.map(x => path.relative(cwd, x)).join(path.delimiter),
-        args;
+  let cwd = process.cwd(),
+    config = require(path.resolve(program.configfile)),
+    configArgs = Object.keys(config),
+    args;
 
-    args = resolver.argsPrefix
-        .concat(['-cp', relativeLibDirs, 'org.flywaydb.commandline.Main'])
-        .concat([cmd._name])
-        .concat(
-            configArgs
-                .filter(x => !!config[x])
-                .map(x => `-${x}=${config[x].replace(/\s/g, '\\ ')}`)
-        );
+  args = resolver.argsPrefix
+    .concat([cmd._name])
+    .concat(
+      configArgs
+        .filter(x => !!config[x])
+        .map(x => `-${x}=${config[x].replace(/\s/g, '\\ ')}`)
+    )
 
-    spawn(resolver.bin, args, {
-        cwd: cwd,
-        stdio: 'inherit',
-        windowsVerbatimArguments: true // Super Weird, https://github.com/nodejs/node/issues/5060
-    });
+  spawn(resolver.bin, args, {
+    cwd: cwd,
+    stdio: 'inherit',
+    windowsVerbatimArguments: true // Super Weird, https://github.com/nodejs/node/issues/5060
+  });
 }

--- a/install.js
+++ b/install.js
@@ -32,17 +32,17 @@ request(`${repoBaseUrl}/maven-metadata.xml`, function (err, response) {
     let completedSuccessfully = false,
         sources = {
             'win32': {
-                url: `${repoBaseUrl}/${latestVersion}/flyway-commandline-${latestVersion}/-windows-x64.zip`,
+                url: `${repoBaseUrl}/${latestVersion}/flyway-commandline-${latestVersion}-windows-x64.zip`,
                 filename: `flyway-commandline-${latestVersion}-windows-x64.zip`,
                 folder: `flyway-${latestVersion}`
             },
             'linux': {
-                url: `${repoBaseUrl}/${latestVersion}/flyway-commandline-${latestVersion}/-linux-x64.tar.gz`,
+                url: `${repoBaseUrl}/${latestVersion}/flyway-commandline-${latestVersion}-linux-x64.tar.gz`,
                 filename: `flyway-commandline-${latestVersion}-linux-x64.tar.gz`,
                 folder: `flyway-${latestVersion}`
             },
             'darwin': {
-                url: `${repoBaseUrl}/${latestVersion}/${latestVersion}//flyway-commandline-${latestVersion}/-macosx-x64.tar.gz`,
+                url: `${repoBaseUrl}/${latestVersion}/${latestVersion}/flyway-commandline-${latestVersion}-macosx-x64.tar.gz`,
                 filename: `flyway-commandline-${latestVersion}-macosx-x64.tar.gz`,
                 folder: `flyway-${latestVersion}`
             }

--- a/install.js
+++ b/install.js
@@ -77,7 +77,7 @@ request(`${repoBaseUrl}/maven-metadata.xml`, function (err, response) {
                 }
 
                 fs.writeFileSync(path.join(jlibDir, 'resolver.js'), `module.exports = ${JSON.stringify({
-                    bin: flywayDir,
+                    bin: path.join(flywayDir, 'flyway'),
                     argsPrefix: argsPrefix
                 }, null, 2)};`);
 

--- a/install.js
+++ b/install.js
@@ -42,7 +42,7 @@ request(`${repoBaseUrl}/maven-metadata.xml`, function (err, response) {
                 folder: `flyway-${latestVersion}`
             },
             'darwin': {
-                url: `${repoBaseUrl}/${latestVersion}/${latestVersion}/flyway-commandline-${latestVersion}-macosx-x64.tar.gz`,
+                url: `${repoBaseUrl}/${latestVersion}/flyway-commandline-${latestVersion}-macosx-x64.tar.gz`,
                 filename: `flyway-commandline-${latestVersion}-macosx-x64.tar.gz`,
                 folder: `flyway-${latestVersion}`
             }

--- a/install.js
+++ b/install.js
@@ -12,203 +12,221 @@ let requestProgress = require('request-progress'),
     fs = require('fs'),
     env = process.env;
 
-let completedSuccessfully = false,
-    sources = {
-        'win32': {
-            url: 'https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.1.0/flyway-commandline-4.1.0-windows-x64.zip',
-            filename: 'flyway-commandline-4.1.0-windows-x64.zip',
-            folder: 'flyway-4.1'
-        },
-        'linux': {
-            url: 'https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.1.0/flyway-commandline-4.1.0-linux-x64.tar.gz',
-            filename: 'flyway-commandline-4.1.0-linux-x64.tar.gz',
-            folder: 'flyway-4.1.0'
-        },
-        'darwin': {
-            url: 'https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.1.0/flyway-commandline-4.1.0-macosx-x64.tar.gz',
-            filename: 'flyway-commandline-4.1.0-macosx-x64.tar.gz',
-            folder: 'flyway-4.1.0'
-        }
-    },
-    currentSource = sources[os.platform()],
-    platformParamEnclosureChar = os.platform() === 'win32' ? '"' : "'";
+let repoBaseUrl = 'https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline';
 
-process.once('exit', function () {
-  if (!completedSuccessfully) {
-    console.log('Install did not complete successfully');
-    process.exit(1);
-  }
-});
+// get latest version
+request(`${repoBaseUrl}/maven-metadata.xml`, function (err, response) {
+    let latestVersion;
+    try {
+        if (err) throw err;
+        
+        let mavenMetadata = response.body;
+        let releaseRegularExp = new RegExp('<release>(.+)<\/release>');
 
-downloadFlywayWithJre()
-    .then(extractToJLib)
-    .then(makeResolverFile)
-    .then(function() {
-        completedSuccessfully = true;
-    }, function(err) {
-        console.log(err);
-    });
-
-function makeResolverFile(jlibDir) {
-    return new Promise(function(res, rej) {
-        let argsPrefix = [],
-            flywayDir = path.join(jlibDir, currentSource.folder);
-
-        if(fs.existsSync(flywayDir)) {
-            if(os.platform() === 'linux') {
-                argsPrefix = ['-Djava.security.egd=file:/dev/../dev/urandom'];
-            }
-
-            fs.writeFileSync(path.join(jlibDir, 'resolver.js'), `module.exports = ${JSON.stringify({
-                bin: path.join(flywayDir, 'jre/bin/java'),
-                argsPrefix: argsPrefix,
-                libDirs: [path.join(flywayDir, 'lib/*'), path.join(flywayDir, 'drivers/*')]
-            }, null, 2)};`);
-
-            res();
-        } else {
-            rej(new Error('flywayDir was not found at ' + flywayDir));
-        }
-    });
-}
-
-function extractToJLib(compressedFlywaySource) {
-    let extractDir = path.join(__dirname, 'jlib');
-
-    if(!fs.existsSync(extractDir)) {
-        fs.mkdirSync(extractDir);
-    } else {
-        return Promise.resolve(extractDir);
+        latestVersion = mavenMetadata.match(releaseRegularExp)[1];
+    } catch (err) {
+        latestVersion = '4.1.0';
+        console.error(`error: could not figure out latest release version. using default version ${latestVersion}`);
     }
 
-    if(path.extname(compressedFlywaySource) === '.zip') {
-        return new Promise(function(res, rej) {
-            extractZip(compressedFlywaySource, { dir: extractDir }, function(err) {
-                if(err) {
-                    console.error('Error extracting zip', err);
-                    rej();
-                } else {
-                    res(extractDir);
-                }
-            });
-        });
-    } else {
-        return new Promise(function(res, rej) {
-            spawn('tar', ['zxf', compressedFlywaySource], {
-                cwd: extractDir,
-                stdio: 'inherit'
-            }).on('close', function(code) {
-                if(code === 0) {
-                    res(extractDir);
-                } else {
-                    console.log('Untaring file failed', code);
-                    rej();
-                }
-            });
-        });
-    }
-}
-
-function downloadFlywayWithJre() {
-    let downloadDir = getCacheDir();
-
-    if(!currentSource) {
-        throw new Error('Your platform is not supported');
-    }
-
-    currentSource.filename = path.join(downloadDir, currentSource.filename);
-
-    if(fs.existsSync(currentSource.filename)) {
-        return Promise.resolve(currentSource.filename);
-    }
-
-    console.log('Downloading', currentSource.url);
-    console.log('Saving to', currentSource.filename);
-
-    return new Promise(function(resolve, reject) {
-        let proxyUrl = env.npm_config_https_proxy || env.npm_config_http_proxy || env.npm_config_proxy,
-            downloadOptions = {
-                uri: currentSource.url,
-                encoding: null, // Get response as a buffer
-                followRedirect: true,
-                headers: {
-                    'User-Agent': env.npm_config_user_agent
-                },
-                strictSSL: true,
-                proxy: proxyUrl
+    let completedSuccessfully = false,
+        sources = {
+            'win32': {
+                url: `${repoBaseUrl}/${latestVersion}/flyway-commandline-${latestVersion}/-windows-x64.zip`,
+                filename: `flyway-commandline-${latestVersion}-windows-x64.zip`,
+                folder: `flyway-${latestVersion}`
             },
-            consoleDownloadBar;
-
-        requestProgress(request(downloadOptions, function (error, response, body) {
-            if (!error && response.statusCode === 200) {
-                fs.writeFileSync(currentSource.filename, body);
-
-                console.log('\nReceived ' + filesize(body.length) + ' total.');
-
-                resolve(currentSource.filename);
-            } else if (response) {
-                console.error(`
-    Error requesting archive.
-    Status: ${response.statusCode}
-    Request options: ${JSON.stringify(downloadOptions, null, 2)}
-    Response headers: ${JSON.stringify(response.headers, null, 2)}
-    Make sure your network and proxy settings are correct.
-
-    If you continue to have issues, please report this full log at https://github.com/markgardner/node-flywaydb`);
-                process.exit(1);
-            } else {
-                console.error('Error downloading archive: ', error);
-                process.exit(1);
+            'linux': {
+                url: `${repoBaseUrl}/${latestVersion}/flyway-commandline-${latestVersion}/-linux-x64.tar.gz`,
+                filename: `flyway-commandline-${latestVersion}-linux-x64.tar.gz`,
+                folder: `flyway-${latestVersion}`
+            },
+            'darwin': {
+                url: `${repoBaseUrl}/${latestVersion}/${latestVersion}//flyway-commandline-${latestVersion}/-macosx-x64.tar.gz`,
+                filename: `flyway-commandline-${latestVersion}-macosx-x64.tar.gz`,
+                folder: `flyway-${latestVersion}`
             }
-        }))
-        .on('progress', function (state) {
-            try {
-                if (!consoleDownloadBar) {
-                    consoleDownloadBar = new ProgressBar('  [:bar] :percent', { total: state.size.total, width: 40 });
+        },
+        currentSource = sources[os.platform()],
+        platformParamEnclosureChar = os.platform() === 'win32' ? '"' : "'";
+
+    process.once('exit', function () {
+      if (!completedSuccessfully) {
+        console.log('Install did not complete successfully');
+        process.exit(1);
+      }
+    });
+
+    downloadFlywayWithJre()
+        .then(extractToJLib)
+        .then(makeResolverFile)
+        .then(function() {
+            completedSuccessfully = true;
+        }, function(err) {
+            console.log(err);
+        });
+
+    function makeResolverFile(jlibDir) {
+        return new Promise(function(res, rej) {
+            let argsPrefix = [],
+                flywayDir = path.join(jlibDir, currentSource.folder);
+
+            if(fs.existsSync(flywayDir)) {
+                if(os.platform() === 'linux') {
+                    argsPrefix = ['-Djava.security.egd=file:/dev/../dev/urandom'];
                 }
 
-                consoleDownloadBar.curr = state.size.transferred;
-                consoleDownloadBar.tick();
-            } catch (e) {
-                console.log('error', e);
+                fs.writeFileSync(path.join(jlibDir, 'resolver.js'), `module.exports = ${JSON.stringify({
+                    bin: flywayDir,
+                    argsPrefix: argsPrefix
+                }, null, 2)};`);
+
+                res();
+            } else {
+                rej(new Error('flywayDir was not found at ' + flywayDir));
             }
         });
-    });
-}
+    }
 
-function getCacheDir() {
-    var tmpDirs = [
-            process.env.npm_config_tmp,
-            os.tmpdir(),
-            path.join(process.cwd(), 'tmp')
-        ],
-        writeAbleTmpDir = tmpDirs.find(dir => {
-            if(dir) {
+    function extractToJLib(compressedFlywaySource) {
+        let extractDir = path.join(__dirname, 'jlib');
+
+        if(!fs.existsSync(extractDir)) {
+            fs.mkdirSync(extractDir);
+        } else {
+            return Promise.resolve(extractDir);
+        }
+
+        if(path.extname(compressedFlywaySource) === '.zip') {
+            return new Promise(function(res, rej) {
+                extractZip(compressedFlywaySource, { dir: extractDir }, function(err) {
+                    if(err) {
+                        console.error('Error extracting zip', err);
+                        rej();
+                    } else {
+                        res(extractDir);
+                    }
+                });
+            });
+        } else {
+            return new Promise(function(res, rej) {
+                spawn('tar', ['zxf', compressedFlywaySource], {
+                    cwd: extractDir,
+                    stdio: 'inherit'
+                }).on('close', function(code) {
+                    if(code === 0) {
+                        res(extractDir);
+                    } else {
+                        console.log('Untaring file failed', code);
+                        rej();
+                    }
+                });
+            });
+        }
+    }
+
+    function downloadFlywayWithJre() {
+        let downloadDir = getCacheDir();
+
+        if(!currentSource) {
+            throw new Error('Your platform is not supported');
+        }
+
+        currentSource.filename = path.join(downloadDir, currentSource.filename);
+
+        if(fs.existsSync(currentSource.filename)) {
+            return Promise.resolve(currentSource.filename);
+        }
+
+        console.log('Downloading', currentSource.url);
+        console.log('Saving to', currentSource.filename);
+
+        return new Promise(function(resolve, reject) {
+            let proxyUrl = env.npm_config_https_proxy || env.npm_config_http_proxy || env.npm_config_proxy,
+                downloadOptions = {
+                    uri: currentSource.url,
+                    encoding: null, // Get response as a buffer
+                    followRedirect: true,
+                    headers: {
+                        'User-Agent': env.npm_config_user_agent
+                    },
+                    strictSSL: true,
+                    proxy: proxyUrl
+                },
+                consoleDownloadBar;
+
+            requestProgress(request(downloadOptions, function (error, response, body) {
+                if (!error && response.statusCode === 200) {
+                    fs.writeFileSync(currentSource.filename, body);
+
+                    console.log('\nReceived ' + filesize(body.length) + ' total.');
+
+                    resolve(currentSource.filename);
+                } else if (response) {
+                    console.error(`
+        Error requesting archive.
+        Status: ${response.statusCode}
+        Request options: ${JSON.stringify(downloadOptions, null, 2)}
+        Response headers: ${JSON.stringify(response.headers, null, 2)}
+        Make sure your network and proxy settings are correct.
+
+        If you continue to have issues, please report this full log at https://github.com/markgardner/node-flywaydb`);
+                    process.exit(1);
+                } else {
+                    console.error('Error downloading archive: ', error);
+                    process.exit(1);
+                }
+            }))
+            .on('progress', function (state) {
                 try {
-                    dir = path.resolve(dir, 'node-flywaydb');
-
-                    if(!fs.existsSync(dir)) {
-                        fs.mkdirSync(dir, '0777');
-                        fs.chmodSync(dir, '0777');
+                    if (!consoleDownloadBar) {
+                        consoleDownloadBar = new ProgressBar('  [:bar] :percent', { total: state.size.total, width: 40 });
                     }
 
-                    let tmpFile = path.join(dir, Date.now() + '.tmp');
-                    fs.writeFileSync(tmpFile, 'test');
-                    fs.unlinkSync(tmpFile);
-
-                    return true;
-                } catch(e) {
-                    console.log(dir, 'is not writable:', e);
+                    consoleDownloadBar.curr = state.size.transferred;
+                    consoleDownloadBar.tick();
+                } catch (e) {
+                    console.log('error', e);
                 }
-            }
-
-            return false;
+            });
         });
-
-    if(writeAbleTmpDir) {
-        return path.resolve(writeAbleTmpDir, 'node-flywaydb');
-    } else {
-        console.error('Can not find a writable tmp directory.');
-        exit(1);
     }
-}
+
+    function getCacheDir() {
+        var tmpDirs = [
+                process.env.npm_config_tmp,
+                os.tmpdir(),
+                path.join(process.cwd(), 'tmp')
+            ],
+            writeAbleTmpDir = tmpDirs.find(dir => {
+                if(dir) {
+                    try {
+                        dir = path.resolve(dir, 'node-flywaydb');
+
+                        if(!fs.existsSync(dir)) {
+                            fs.mkdirSync(dir, '0777');
+                            fs.chmodSync(dir, '0777');
+                        }
+
+                        let tmpFile = path.join(dir, Date.now() + '.tmp');
+                        fs.writeFileSync(tmpFile, 'test');
+                        fs.unlinkSync(tmpFile);
+
+                        return true;
+                    } catch(e) {
+                        console.log(dir, 'is not writable:', e);
+                    }
+                }
+
+                return false;
+            });
+
+        if(writeAbleTmpDir) {
+            return path.resolve(writeAbleTmpDir, 'node-flywaydb');
+        } else {
+            console.error('Can not find a writable tmp directory.');
+            exit(1);
+        }
+    }
+
+});

--- a/install.js
+++ b/install.js
@@ -15,19 +15,19 @@ let requestProgress = require('request-progress'),
 let completedSuccessfully = false,
     sources = {
         'win32': {
-            url: 'https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.0.3/flyway-commandline-4.0.3-windows-x64.zip',
-            filename: 'flyway-commandline-4.0.3-windows-x64.zip',
-            folder: 'flyway-4.0.3'
+            url: 'https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.1.0/flyway-commandline-4.1.0-windows-x64.zip',
+            filename: 'flyway-commandline-4.1.0-windows-x64.zip',
+            folder: 'flyway-4.1'
         },
         'linux': {
-            url: 'https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.0.3/flyway-commandline-4.0.3-linux-x64.tar.gz',
-            filename: 'flyway-commandline-4.0.3-linux-x64.tar.gz',
-            folder: 'flyway-4.0.3'
+            url: 'https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.1.0/flyway-commandline-4.1.0-linux-x64.tar.gz',
+            filename: 'flyway-commandline-4.1.0-linux-x64.tar.gz',
+            folder: 'flyway-4.1.0'
         },
         'darwin': {
-            url: 'https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.0.3/flyway-commandline-4.0.3-macosx-x64.tar.gz',
-            filename: 'flyway-commandline-4.0.3-macosx-x64.tar.gz',
-            folder: 'flyway-4.0.3'
+            url: 'https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.1.0/flyway-commandline-4.1.0-macosx-x64.tar.gz',
+            filename: 'flyway-commandline-4.1.0-macosx-x64.tar.gz',
+            folder: 'flyway-4.1.0'
         }
     },
     currentSource = sources[os.platform()],


### PR DESCRIPTION
I modified the wrapper to fetch the latest release version (taken from https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/maven-metadata.xml)

also, now the commands are executed directly on the dedicated bash script, just like the tool developers intended originally