### PR TITLE
Add ability to turn on slf4j logging

### DIFF
--- a/bin/flyway
+++ b/bin/flyway
@@ -45,11 +45,17 @@ function exeCommand(cmd) {
     let cwd = process.cwd(),
         config = require(path.resolve(program.configfile)), 
         configArgs = Object.keys(config),
+        javaOpts = config.javaOpts || [],
         relativeLibDirs = resolver.libDirs.map(x => path.relative(cwd, x)).join(path.delimiter),
         args;
 
+    // Removing javaOpts now that we've saved them so they aren't included with the rest of the config.
+    configArgs = configArgs.filter(arg => arg !== 'javaOpts');
+
     args = resolver.argsPrefix
-        .concat(['-cp', relativeLibDirs, 'org.flywaydb.commandline.Main'])
+        .concat(['-cp', relativeLibDirs])
+        .concat(javaOpts)
+        .concat(['org.flywaydb.commandline.Main'])
         .concat([cmd._name])
         .concat(
             configArgs

--- a/example_config_with_logging.js
+++ b/example_config_with_logging.js
@@ -1,0 +1,21 @@
+var env = process.env;
+
+module.exports = {
+    javaOpts: [
+        '-Djava.util.logging.config.file=./conf/logging.properties'
+    ],
+    url: `jdbc:postgresql://${env.PGHOST}:${env.PGPORT}/${env.PGDATABASE}`,
+    schemas: 'public',
+    locations: 'filesystem:sql/migrations',
+    user: env.PGUSER,
+    password: env.PGPASSWORD,
+    sqlMigrationSuffix: '.pgsql'
+};
+
+/* example conf/logging.properties file contents:
+
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=FINEST
+org.flywaydb.level=FINEST
+
+*/

--- a/install.js
+++ b/install.js
@@ -55,6 +55,7 @@ downloadFlywayWithJre()
 function makeResolverFile(jlibDir) {
     return new Promise(function(res, rej) {
         let argsPrefix = [],
+            fileContents,
             flywayDir = path.join(jlibDir, currentSource.folder);
 
         if(fs.existsSync(flywayDir)) {
@@ -62,11 +63,20 @@ function makeResolverFile(jlibDir) {
                 argsPrefix = ['-Djava.security.egd=file:/dev/../dev/urandom'];
             }
 
-            fs.writeFileSync(path.join(jlibDir, 'resolver.js'), `module.exports = ${JSON.stringify({
-                bin: path.join(flywayDir, 'jre/bin/java'),
-                argsPrefix: argsPrefix,
-                libDirs: [path.join(flywayDir, 'lib/*'), path.join(flywayDir, 'drivers/*')]
-            }, null, 2)};`);
+            fileContents = `
+const path = require('path');
+
+module.exports = {
+    bin: path.join(__dirname, 'flyway-${flywayVersion}/jre/bin/java'),
+    argsPrefix: ${JSON.stringify(argsPrefix)},
+    libDirs: [
+        path.join(__dirname, 'flyway-${flywayVersion}/lib/*'),
+        path.join(__dirname, 'flyway-${flywayVersion}/drivers/*')
+    ]
+};
+`;
+
+            fs.writeFileSync(path.join(jlibDir, 'resolver.js'), fileContents);
 
             res();
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-flywaydb",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "NodeJs wrapper for flywaydb cli",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
After having lots of trouble getting flyway to work with heroku's postgres plugin, I decided I needed to be able to tweak flyway's slf4j logging to figure out what is going on.

This PR adds that capability to your wrapper.

I decided to just pick one slf4j implementation instead of making the config more complex and allowing people to pick whatever slf4j implementation they wanted.  I chose the jdk logger (instead of log4j, jcl, simple, etc.) because it was small and self contained.
