### PR TITLE
Download expiration time config

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -7,6 +7,7 @@ const extractZip = require('extract-zip');
 const spawn = require('child_process').spawn;
 
 const ONE_DAY_MS = 8.64e+7;
+const NEVER_EXPIRE_DOWNLOADS = -1;
 
 function downloadOptions(url) {
     const env = process.env;
@@ -31,9 +32,10 @@ function downloadOptions(url) {
     };
 }
 
-function saveCachedUrlToPath(destinationPath, url) {
+function saveCachedUrlToPath(destinationPath, url, downloadExpirationTimeMs) {
+    const expirationTime = downloadExpirationTimeMs || ONE_DAY_MS;
     const stats = fs.existsSync(destinationPath) ? fs.statSync(destinationPath) : null;
-    const useCachedVersion = stats && Date.now() - stats.mtimeMs < ONE_DAY_MS;
+    const useCachedVersion = stats && (expirationTime === NEVER_EXPIRE_DOWNLOADS || (stats && Date.now() - stats.mtimeMs < expirationTime));
 
     if(useCachedVersion) {
         return Promise.resolve(destinationPath);
@@ -68,12 +70,12 @@ function nodePlatformToMavinSuffix() {
     })[os.platform()];
 }
 
-function resolveMavenVersion(libDir, groupId, artifactId, version) {
+function resolveMavenVersion(libDir, groupId, artifactId, version, downloadExpirationTimeMs) {
     if(version && version !== 'latest') {
         return Promise.resolve(version);
     } else {
         const latestCacheFile = path.join(libDir, `${groupId}_${artifactId}.latest`);
-        const xmlReqeust = saveCachedUrlToPath(latestCacheFile, `https://repo1.maven.org/maven2/${groupId.replace(/\./g, '/')}/${artifactId}/maven-metadata.xml`);
+        const xmlReqeust = saveCachedUrlToPath(latestCacheFile, `https://repo1.maven.org/maven2/${groupId.replace(/\./g, '/')}/${artifactId}/maven-metadata.xml`, downloadExpirationTimeMs);
 
         return xmlReqeust
             .then(function(manifestFilePath) {
@@ -98,13 +100,13 @@ function resolveMavenVersion(libDir, groupId, artifactId, version) {
     }
 }
 
-function downloadMaven(libDir, groupId, artifactId, version) {
-    return resolveMavenVersion(libDir, groupId, artifactId, version)
+function downloadMaven(libDir, groupId, artifactId, version, downloadExpirationTimeMs) {
+    return resolveMavenVersion(libDir, groupId, artifactId, version, downloadExpirationTimeMs)
         .then(function(version) {
             if(version.match(/^https/)) {
                 const flywaySavePath = path.join(libDir, path.basename(version));
 
-                return saveCachedUrlToPath(flywaySavePath, version)
+                return saveCachedUrlToPath(flywaySavePath, version, downloadExpirationTimeMs)
                     .then(function (fileSavePath) {
                         return {
                             version,
@@ -117,7 +119,7 @@ function downloadMaven(libDir, groupId, artifactId, version) {
                 const flywayUrl = `https://repo1.maven.org/maven2/${groupId.replace(/\./g, '/')}/${artifactId}/${version}/${artifactId}-${version}-${platformSuffix}`;
                 const flywaySavePath = path.join(libDir, `${artifactId}-${version}-${platformSuffix}`);
 
-                return saveCachedUrlToPath(flywaySavePath, flywayUrl)
+                return saveCachedUrlToPath(flywaySavePath, flywayUrl, downloadExpirationTimeMs)
                     .then(function (fileSavePath) {
                         return {
                             version,
@@ -130,7 +132,7 @@ function downloadMaven(libDir, groupId, artifactId, version) {
                 const depUrl = `https://repo1.maven.org/maven2/${groupId.replace(/\./g, '/')}/${artifactId}/${version}/${artifactId}-${version}.jar`;
                 const depSavePath = path.join(libDir, `${artifactId}-${version}.jar`);
 
-                return saveCachedUrlToPath(depSavePath, depUrl)
+                return saveCachedUrlToPath(depSavePath, depUrl, downloadExpirationTimeMs)
                     .then(function (fileSavePath) {
                         return {
                             version,
@@ -200,11 +202,12 @@ function ensureWritableLibDir() {
 module.exports = {
     ensureArtifacts: function(config, callback) {
         const libDir = ensureWritableLibDir();
-        var pendingDownloads = [downloadMaven(libDir, 'org.flywaydb', 'flyway-commandline', config.downloadUrl || config.version)];
+        const downloadExpirationTimeMs = config.downloads && config.downloads.expirationTimeInMs;
+        var pendingDownloads = [downloadMaven(libDir, 'org.flywaydb', 'flyway-commandline', config.downloadUrl || config.version, downloadExpirationTimeMs)];
 
         if(config.mavinPlugins) {
             pendingDownloads = pendingDownloads.concat(config.mavinPlugins.map(function(plugin) {
-                return downloadMaven(libDir, plugin.groupId, plugin.artifactId, plugin.downloadUrl || plugin.version);
+                return downloadMaven(libDir, plugin.groupId, plugin.artifactId, plugin.downloadUrl || plugin.version, downloadExpirationTimeMs);
             }));
         }
 

--- a/lib/download.js
+++ b/lib/download.js
@@ -35,7 +35,7 @@ function downloadOptions(url) {
 function saveCachedUrlToPath(destinationPath, url, downloadExpirationTimeMs) {
     const expirationTime = downloadExpirationTimeMs || ONE_DAY_MS;
     const stats = fs.existsSync(destinationPath) ? fs.statSync(destinationPath) : null;
-    const useCachedVersion = stats && (expirationTime === NEVER_EXPIRE_DOWNLOADS || (stats && Date.now() - stats.mtimeMs < expirationTime));
+    const useCachedVersion = stats && (expirationTime === NEVER_EXPIRE_DOWNLOADS || (Date.now() - stats.mtimeMs < expirationTime));
 
     if(useCachedVersion) {
         return Promise.resolve(destinationPath);

--- a/sample/config.js
+++ b/sample/config.js
@@ -22,5 +22,8 @@ module.exports = {
         groupId: 'org.slf4j',
         artifactId: 'slf4j-jdk14',
         version: '1.7.25'
-    }]
+    }],
+    downloads: {
+        expirationTimeInMs: -1,
+    }
 };


### PR DESCRIPTION
This merge request makes it possible to config the expiration time of any cached `node-flywaydb` download.

Setting it as `-1` will set expiration time to never.
```
    downloads: {
        expirationTimeInMs: -1,
    }
```