### PR TITLE
feat: add `.npmignore` to remove unused files from pack

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+node_modules
+
+# dirs
+sample/
+
+# linters and other style configs
+.eslintrc.js
+.editorconfig
+
+# docker
+docker-compose.yml


### PR DESCRIPTION
Аfter examining the source code I noticed that some unused files packed into package.
`.npmignore` allows to exclude this files.