### PR TITLE
Fix https://github.com/markgardner/node-flywaydb/issues/34

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -201,17 +201,14 @@ function downloadMaven(libDir, groupId, artifactId, version, downloadExpirationT
                     fs.mkdirSync(extractDir);
 
                     if(fileExt === '.zip') {
-                        return new Promise(function(res, rej) {
-                            extractZip(file, { dir: extractDir }, function(err) {
-                                if(err) {
-                                    rimraf.sync(extractDir);
-
-                                    rej(err);
-                                } else {
-                                    res({ version, type, dir: extractDir });
-                                }
+                        return extractZip(file, { dir: extractDir })
+                            .then(function () {
+                                return { version, type, dir: extractDir };
+                            })
+                            .catch(function (err) {
+                                rimraf.sync(extractDir);
+                                throw err;
                             });
-                        });
                     } else {
                         return new Promise(function(res, rej) {
                             spawn('tar', ['zxf', file], {


### PR DESCRIPTION
extract-zip: Replace callback-style API with promise-style API