### PR TITLE
Add support for downloading generic flyway cmd without bundled jre

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -112,9 +112,9 @@ function saveCachedUrlToPath(destinationPath, url, downloadExpirationTimeMs) {
 
 function nodePlatformToMavenSuffix() {
     return ({
-        'win32': 'windows-x64.zip',
-        'linux': 'linux-x64.tar.gz',
-        'darwin': 'macosx-x64.tar.gz'
+        'win32': '-windows-x64.zip',
+        'linux': '-linux-x64.tar.gz',
+        'darwin': '-macosx-x64.tar.gz'
     })[os.platform()];
 }
 
@@ -148,8 +148,8 @@ function resolveMavenVersion(libDir, groupId, artifactId, version, downloadExpir
     }
 }
 
-function downloadMaven(libDir, groupId, artifactId, version, downloadExpirationTimeMs) {
-    return resolveMavenVersion(libDir, groupId, artifactId, version, downloadExpirationTimeMs)
+function downloadMaven(libDir, groupId, artifactId, version, downloadExpirationTimeMs, localJava) {
+    return resolveMavenVersion(libDir, groupId, artifactId, version, downloadExpirationTimeMs, localJava)
         .then(function(version) {
             if(version.match(/^https/)) {
                 const flywaySavePath = path.join(libDir, path.basename(version));
@@ -163,9 +163,9 @@ function downloadMaven(libDir, groupId, artifactId, version, downloadExpirationT
                         };
                     });
             } else if(artifactId === 'flyway-commandline') {
-                const platformSuffix = nodePlatformToMavenSuffix();
-                const flywayUrl = `https://repo1.maven.org/maven2/${groupId.replace(/\./g, '/')}/${artifactId}/${version}/${artifactId}-${version}-${platformSuffix}`;
-                const flywaySavePath = path.join(libDir, `${artifactId}-${version}-${platformSuffix}`);
+                const platformSuffix = localJava ? '.tar.gz' : nodePlatformToMavenSuffix();
+                const flywayUrl = `https://repo1.maven.org/maven2/${groupId.replace(/\./g, '/')}/${artifactId}/${version}/${artifactId}-${version}${platformSuffix}`;
+                const flywaySavePath = path.join(libDir, `${artifactId}-${version}${platformSuffix}`);
 
                 return saveCachedUrlToPath(flywaySavePath, flywayUrl, downloadExpirationTimeMs)
                     .then(function (fileSavePath) {
@@ -255,13 +255,13 @@ module.exports = {
     ensureArtifacts: function(config, callback) {
         const libDir = ensureWritableLibDir(config.downloads && config.downloads.storageDirectory);
         const downloadExpirationTimeMs = config.downloads && config.downloads.expirationTimeInMs;
-        var pendingDownloads = [downloadMaven(libDir, 'org.flywaydb', 'flyway-commandline', config.downloadUrl || config.version, downloadExpirationTimeMs)];
+        var pendingDownloads = [downloadMaven(libDir, 'org.flywaydb', 'flyway-commandline', config.downloadUrl || config.version, downloadExpirationTimeMs, config.localJava)];
 
         // Checking config.mavinPlugins to ensure backwards compatibility with older versions of node-flyway that defined it as 'config.mavinPlugins' and not 'config.MavenPlugins'
         if(config.mavenPlugins || config.mavinPlugins) {
             const plugins = config.mavinPlugins === undefined ? config.mavenPlugins : config.mavinPlugins;
             pendingDownloads = pendingDownloads.concat(plugins.map(function(plugin) {
-                return downloadMaven(libDir, plugin.groupId, plugin.artifactId, plugin.downloadUrl || plugin.version, downloadExpirationTimeMs);
+                return downloadMaven(libDir, plugin.groupId, plugin.artifactId, plugin.downloadUrl || plugin.version, downloadExpirationTimeMs, config.localJava);
             }));
         }
 

--- a/sample/config.js
+++ b/sample/config.js
@@ -9,12 +9,14 @@ module.exports = function() {
             password: 'example',
             sqlMigrationSuffixes: '.pgsql',
             baselineOnMigrate: true,
+
         },
         // Use to configure environment variables used by flyway
         env: {
             JAVA_ARGS: '-Djava.util.logging.config.file=./conf/logging.properties',
         },
         version: '6.3.2', // optional, empty or missing will download the latest
+        localJava: false, // optional, if true use locally installed java, with false is used bundled JRE from flyway cmd, flyway cmd doesn't have bundled JRE for architectures like armv6
         mavenPlugins: [{ // optional, use to add any plugins (ie. logging)
             groupId: 'org.slf4j',
             artifactId: 'slf4j-api',


### PR DESCRIPTION
Add support for downloading generic flyway cmd without bundled java - useful for eg. armv6 devices for which flyway cmd does not have bundled JRE. Flyway then uses locally installed java.