### PR TITLE
Make node-flywaydb callable from JavaScript

### DIFF
--- a/bin/flyway.js
+++ b/bin/flyway.js
@@ -7,6 +7,7 @@ const pkg = require('../package.json');
 const exeCommand = require('../lib/exec').exeCommand
 
 
+
 process.title = 'flyway';
 program
     .version(pkg.version)
@@ -37,5 +38,5 @@ function makeCommand(name, desc) {
     program
         .command(name)
         .description(desc)
-        .action(exeCommand);
+        .action(exeCommand(program.configfile));
 }

--- a/bin/flyway.js
+++ b/bin/flyway.js
@@ -44,7 +44,6 @@ function makeCommand(name, desc) {
 }
 
 function cliExec(cmd) {
-  console.log(cmd);
   if(!program.configfile) {
     throw new Error('Config file option is required');
   }

--- a/bin/flyway.js
+++ b/bin/flyway.js
@@ -5,6 +5,7 @@
 const program = require('commander');
 const pkg = require('../package.json');
 const exeCommand = require('../lib/exec').exeCommand
+const path = require('path');
 
 
 
@@ -15,6 +16,7 @@ program
     .on('--help', function() {
         console.log('  See Flyway\'s configuration options at https://flywaydb.org/documentation/commandline/');
     });
+
 
 makeCommand('migrate', 'Migrates the schema to the latest version. Flyway will create the metadata table automatically if it doesn\'t exist.');
 makeCommand('clean', 'Drops all objects (tables, views, procedures, triggers, ...) in the configured schemas. The schemas are cleaned in the order specified by the schemas property.');
@@ -38,5 +40,18 @@ function makeCommand(name, desc) {
     program
         .command(name)
         .description(desc)
-        .action(exeCommand(program.configfile));
+        .action(cliExec);
+}
+
+function cliExec(cmd) {
+  if(!program.configfile) {
+    throw new Error('Config file option is required');
+  }
+
+  var config = require(path.resolve(program.configfile));
+
+  if (typeof config === 'function') {
+      config = config();
+  }
+  return exeCommand(config, cmd);
 }

--- a/bin/flyway.js
+++ b/bin/flyway.js
@@ -44,6 +44,7 @@ function makeCommand(name, desc) {
 }
 
 function cliExec(cmd) {
+  console.log(cmd);
   if(!program.configfile) {
     throw new Error('Config file option is required');
   }
@@ -53,5 +54,5 @@ function cliExec(cmd) {
   if (typeof config === 'function') {
       config = config();
   }
-  return exeCommand(config, cmd);
+  return exeCommand(config, cmd).then(code => process.exit(code));
 }

--- a/bin/flyway.js
+++ b/bin/flyway.js
@@ -3,12 +3,9 @@
 'use strict';
 
 const program = require('commander');
-const path = require('path');
-const spawn = require('child_process').spawn;
-const fs = require('fs');
-const os = require('os');
 const pkg = require('../package.json');
-const download = require('../lib/download');
+const exeCommand = require('../lib/exec').exeCommand
+
 
 process.title = 'flyway';
 program
@@ -41,65 +38,4 @@ function makeCommand(name, desc) {
         .command(name)
         .description(desc)
         .action(exeCommand);
-}
-
-function configFlywayArgs(config) {
-    const flywayArgs = config.flywayArgs || {};
-    const flywayArgsKeys = Object.keys(flywayArgs);
-
-    return flywayArgsKeys.map(function(key) {
-        return `-${key}=${flywayArgs[key]}`;
-    });
-}
-
-function binIsFile(path) {
-    const stats = fs.statSync(path);
-
-    return !!stats && stats.isFile();
-}
-
-function exeCommand(cmd) {
-    if(!program.configfile) {
-        throw new Error('Config file option is required');
-    }
-
-    var config = require(path.resolve(program.configfile));
-
-    if (typeof config === 'function') {
-        config = config();
-    }
-
-    download.ensureArtifacts(config, function(err, flywayBin) {
-        const workingDir = process.cwd();
-
-        if(err) {
-            throw new Error(err);
-        }
-
-        // Ensure that the flywayBin is a file, helps with security risk of having
-        // shell true in the spawn call below
-        if (!binIsFile(flywayBin)) {
-            throw new Error('Flyway bin was not found at "' + flywayBin + '"');
-        }
-
-        const args = configFlywayArgs(config)
-            .concat([cmd._name]);
-
-        // Fix problem with spaces on windows OS
-        // https://github.com/nodejs/node/issues/7367
-        const isWindowsAndHasSpace = !!(flywayBin.match(/\s/) && os.platform() === 'win32');
-        const safeSpawnBin = isWindowsAndHasSpace ? '"' + flywayBin + '"' : flywayBin;
-
-        const child = spawn(safeSpawnBin, args, {
-            env: Object.assign({}, process.env, config.env),
-            cwd: workingDir,
-            stdio: 'inherit',
-            windowsVerbatimArguments: true, // Super Weird, https://github.com/nodejs/node/issues/5060
-            shell: isWindowsAndHasSpace,
-        });
-
-        child.on('close', code => {
-            process.exit(code);
-        });
-    });
 }

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -2,6 +2,7 @@ const download = require('./download');
 const spawn = require('child_process').spawn;
 const fs = require('fs');
 const os = require('os');
+const { resolve } = require('path');
 
 function configFlywayArgs(config) {
     const flywayArgs = config.flywayArgs || {};
@@ -19,41 +20,44 @@ function binIsFile(path) {
 }
 
 function exeCommand(config, cmd) { 
-    download.ensureArtifacts(config, function(err, flywayBin) {
-        const workingDir = process.cwd();
+    return new Promise((resolve, _) => {
+        download.ensureArtifacts(config, function(err, flywayBin) {
+            const workingDir = process.cwd();
 
-        if(err) {
-            throw new Error(err);
+            if(err) {
+                throw new Error(err);
+            }
+
+            // Ensure that the flywayBin is a file, helps with security risk of having
+            // shell true in the spawn call below
+            if (!binIsFile(flywayBin)) {
+                throw new Error('Flyway bin was not found at "' + flywayBin + '"');
+            }
+
+            const args = configFlywayArgs(config)
+                .concat([cmd._name]);
+
+            // Fix problem with spaces on windows OS
+            // https://github.com/nodejs/node/issues/7367
+            const isWindowsAndHasSpace = !!(flywayBin.match(/\s/) && os.platform() === 'win32');
+            const safeSpawnBin = isWindowsAndHasSpace ? '"' + flywayBin + '"' : flywayBin;
+
+            const child = spawn(safeSpawnBin, args, {
+                env: Object.assign({}, process.env, config.env),
+                cwd: workingDir,
+                stdio: 'inherit',
+                windowsVerbatimArguments: true, // Super Weird, https://github.com/nodejs/node/issues/5060
+                shell: isWindowsAndHasSpace,
+            });
+
+            child.on('close', code => {
+                resolve(code)
+            });
         }
-
-        // Ensure that the flywayBin is a file, helps with security risk of having
-        // shell true in the spawn call below
-        if (!binIsFile(flywayBin)) {
-            throw new Error('Flyway bin was not found at "' + flywayBin + '"');
-        }
-
-        const args = configFlywayArgs(config)
-            .concat([cmd._name]);
-
-        // Fix problem with spaces on windows OS
-        // https://github.com/nodejs/node/issues/7367
-        const isWindowsAndHasSpace = !!(flywayBin.match(/\s/) && os.platform() === 'win32');
-        const safeSpawnBin = isWindowsAndHasSpace ? '"' + flywayBin + '"' : flywayBin;
-
-        const child = spawn(safeSpawnBin, args, {
-            env: Object.assign({}, process.env, config.env),
-            cwd: workingDir,
-            stdio: 'inherit',
-            windowsVerbatimArguments: true, // Super Weird, https://github.com/nodejs/node/issues/5060
-            shell: isWindowsAndHasSpace,
-        });
-
-        child.on('close', code => {
-            process.exit(code);
-        });
-    });
+    )});   
 };
 
 module.exports = {
-    exeCommand: function(config) { exeCommand(config) }
+    exeCommand: function(config, cmd) { return exeCommand(config, cmd) },
+    migrate: function(config) { return exeCommand(config, { _name: 'migrate' } )}
 };

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,10 +1,8 @@
 const download = require('./download');
-const path = require('path');
 const spawn = require('child_process').spawn;
 const fs = require('fs');
 const os = require('os');
-const program = require('commander');
-
+const path = require('path');
 
 function configFlywayArgs(config) {
     const flywayArgs = config.flywayArgs || {};
@@ -21,12 +19,12 @@ function binIsFile(path) {
     return !!stats && stats.isFile();
 }
 
-function exeCommand(cmd) {
-    if(!program.configfile) {
+function exeCommand(configfile) { (cmd)  => {
+    if(!configfile) {
         throw new Error('Config file option is required');
     }
 
-    var config = require(path.resolve(program.configfile));
+    var config = require(path.resolve(configfile));
 
     if (typeof config === 'function') {
         config = config();
@@ -66,7 +64,8 @@ function exeCommand(cmd) {
         });
     });
 }
+};
 
 module.exports = {
-    exeCommand: function(cmd) { exeCommand(cmd) }
-}
+    exeCommand: function(config) { exeCommand(config) }
+};

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,0 +1,72 @@
+const download = require('./download');
+const path = require('path');
+const spawn = require('child_process').spawn;
+const fs = require('fs');
+const os = require('os');
+const program = require('commander');
+
+
+function configFlywayArgs(config) {
+    const flywayArgs = config.flywayArgs || {};
+    const flywayArgsKeys = Object.keys(flywayArgs);
+
+    return flywayArgsKeys.map(function(key) {
+        return `-${key}=${flywayArgs[key]}`;
+    });
+}
+
+function binIsFile(path) {
+    const stats = fs.statSync(path);
+
+    return !!stats && stats.isFile();
+}
+
+function exeCommand(cmd) {
+    if(!program.configfile) {
+        throw new Error('Config file option is required');
+    }
+
+    var config = require(path.resolve(program.configfile));
+
+    if (typeof config === 'function') {
+        config = config();
+    }
+
+    download.ensureArtifacts(config, function(err, flywayBin) {
+        const workingDir = process.cwd();
+
+        if(err) {
+            throw new Error(err);
+        }
+
+        // Ensure that the flywayBin is a file, helps with security risk of having
+        // shell true in the spawn call below
+        if (!binIsFile(flywayBin)) {
+            throw new Error('Flyway bin was not found at "' + flywayBin + '"');
+        }
+
+        const args = configFlywayArgs(config)
+            .concat([cmd._name]);
+
+        // Fix problem with spaces on windows OS
+        // https://github.com/nodejs/node/issues/7367
+        const isWindowsAndHasSpace = !!(flywayBin.match(/\s/) && os.platform() === 'win32');
+        const safeSpawnBin = isWindowsAndHasSpace ? '"' + flywayBin + '"' : flywayBin;
+
+        const child = spawn(safeSpawnBin, args, {
+            env: Object.assign({}, process.env, config.env),
+            cwd: workingDir,
+            stdio: 'inherit',
+            windowsVerbatimArguments: true, // Super Weird, https://github.com/nodejs/node/issues/5060
+            shell: isWindowsAndHasSpace,
+        });
+
+        child.on('close', code => {
+            process.exit(code);
+        });
+    });
+}
+
+module.exports = {
+    exeCommand: function(cmd) { exeCommand(cmd) }
+}

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -2,7 +2,6 @@ const download = require('./download');
 const spawn = require('child_process').spawn;
 const fs = require('fs');
 const os = require('os');
-const path = require('path');
 
 function configFlywayArgs(config) {
     const flywayArgs = config.flywayArgs || {};
@@ -19,17 +18,7 @@ function binIsFile(path) {
     return !!stats && stats.isFile();
 }
 
-function exeCommand(configfile) { (cmd)  => {
-    if(!configfile) {
-        throw new Error('Config file option is required');
-    }
-
-    var config = require(path.resolve(configfile));
-
-    if (typeof config === 'function') {
-        config = config();
-    }
-
+function exeCommand(config, cmd) { 
     download.ensureArtifacts(config, function(err, flywayBin) {
         const workingDir = process.cwd();
 
@@ -63,7 +52,6 @@ function exeCommand(configfile) { (cmd)  => {
             process.exit(code);
         });
     });
-}
 };
 
 module.exports = {


### PR DESCRIPTION
We want to be able to run migrations directly from javascript so that we can run our migrations to setup our embedded test databases. This change refactors the code to make that possible and exposes a 'migrate' function which takes a config object and runs migrate with that config object. This could be easily expanded to expose more functions, like 'baseline' in a similar way.